### PR TITLE
Fixup the coliding hashes of the dual protobuf builds - 2023.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ source:
     folder: thirdparty/onnx/onnx
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -80,6 +80,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - pugixml
         - tbb-devel
     test:
@@ -114,6 +116,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - pugixml
         - {{ pin_subpackage('libopenvino', exact=True) }}
       run:
@@ -201,6 +205,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - {{ pin_subpackage('libopenvino', exact=True) }}
       run:
         - {{ pin_subpackage('libopenvino', exact=True) }}
@@ -260,6 +266,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - {{ pin_subpackage('libopenvino', exact=True) }}
       run:
         - {{ pin_subpackage('libopenvino', exact=True) }}
@@ -287,6 +295,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - pugixml
         - tbb-devel
         - {{ pin_subpackage('libopenvino', exact=True) }}
@@ -315,6 +325,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - pugixml
         - tbb-devel
         - {{ pin_subpackage('libopenvino', exact=True) }}
@@ -342,6 +354,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - tbb-devel
         - ocl-icd  # [linux64]
         - clhpp
@@ -371,6 +385,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - tbb-devel
         - {{ pin_subpackage('libopenvino', exact=True) }}
       run:
@@ -396,6 +412,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - tbb-devel
         - {{ pin_subpackage('libopenvino', exact=True) }}
       run:
@@ -421,6 +439,8 @@ outputs:
         - {{ compiler('c') }}
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - pugixml
         - {{ pin_subpackage('libopenvino', exact=True) }}
       run:
@@ -461,6 +481,8 @@ outputs:
         - pybind11
         - wheel
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         - tbb-devel  # for OpenVINO Developer package only
         - pugixml  # for OpenVINO Developer package only
         - python
@@ -560,6 +582,8 @@ outputs:
       build:
         - cmake
       host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
         # hmaarrfk: 2024/01
         # without the tbb-devel package in the host section, we won't be able to drag on
         # the comaptible dependency below

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -667,9 +667,12 @@ outputs:
         - {{ pin_subpackage('libopenvino-tensorflow-frontend', max_pin='x.x.x') }}
         - {{ pin_subpackage('libopenvino-tensorflow-lite-frontend', max_pin='x.x.x') }}
     requirements:
+      host:
+        # hmaarrfk -- libprotobuf added to ensure that each protobuf builds has a a different hash
+        - libprotobuf
       run:
         - {{ pin_subpackage('libopenvino-dev', exact=True) }}
-        # Do not use the exact pin here since we are generating multiple different 
+        # Do not use the exact pin here since we are generating multiple different
         # python packages in 1 go. Instead let the common python constraints
         # choose the same variant of the package
         # - {{ pin_subpackage('libopenvino-python', exact=True) }}


### PR DESCRIPTION
See https://github.com/conda-forge/openvino-feedstock/pull/86 for explination

- [ ] verified the hashes are different for the two versions of libprotobuf
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
